### PR TITLE
removes unused css for split-buttons

### DIFF
--- a/split-buttons/split-button.css
+++ b/split-buttons/split-button.css
@@ -72,11 +72,6 @@
   & > button {
     border-radius: var(--radius) 0 0 var(--radius);
 
-    & > svg {
-      fill: none;
-      stroke: var(--ontheme);
-    }
-  
     @supports (border-start-start-radius: 1px) {
       border-end-start-radius: var(--radius);
       border-start-start-radius: var(--radius);


### PR DESCRIPTION
There is no element matches the this selector. Maybe just forget to remove it.

```html
<element class="gui-split-button">
  <button>
    <svg>
```