### PR TITLE
fixes dialog delete observer variable names

### DIFF
--- a/dialog/dialog.js
+++ b/dialog/dialog.js
@@ -34,8 +34,8 @@ const dialogDeleteObserver = new MutationObserver((mutations, observer) => {
   mutations.forEach(mutation => {
     mutation.removedNodes.forEach(removedNode => {
       if (removedNode.nodeName === 'DIALOG') {
-        dialog.removeEventListener('click', lightDismiss)
-        dialog.removeEventListener('close', dialogClose)
+        removedNode.removeEventListener('click', lightDismiss)
+        removedNode.removeEventListener('close', dialogClose)
         removedNode.dispatchEvent(dialogRemovedEvent)
       }
     })


### PR DESCRIPTION
Hi,

I was just reading and playing with the newly released dialog (which is awesome by the way) and stumbled across the potential typos in the dialog delete observer callback.

Thanks for amazing gui-challanges!