### PR TITLE
Patch 1

### DIFF
--- a/dialog/index.css
+++ b/dialog/index.css
@@ -98,6 +98,7 @@ main {
   position: absolute;
   right: 4px;
   width: 80px;
+  height: 80px;
   fill: var(--surface-4);
   color: var(--surface-1);
   

--- a/dialog/index.css
+++ b/dialog/index.css
@@ -94,15 +94,12 @@ main {
   }
 }
 
-
-
-
-
-
-
 .github-corner {
+  position: absolute;
+  right: 4px;
+  width: 80px;
   fill: var(--surface-4);
-  color: var(--surface-1); 
+  color: var(--surface-1);
   
   &:hover .octo-arm {
     animation: octocat-wave 560ms ease-in-out


### PR DESCRIPTION
Added styles to the github-corner element to prevent an empty focus ring under the avatars when we focus on the github corner element. Now the focus ring should be displayed around the github corner element, which improves accessibility

Before state:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/15846102/163320455-788b5d06-2eda-4a49-9be8-54bafb8949d9.png">

After state: 
<img width="132" alt="image" src="https://user-images.githubusercontent.com/15846102/163320524-34184958-01ff-4256-894f-ccc561a3a92f.png">

