### PR TITLE
Fixing accNames

### DIFF
--- a/dialog/index.html
+++ b/dialog/index.html
@@ -82,7 +82,7 @@
     <main>
       <div class="user">
         <img src="https://doodleipsum.com/700x700/avatar-5?i=e49dd48962488beade4c44491e56a5a9" alt="">
-        <button title="Remove user">
+        <button aria-label="Remove user 1">
           <svg width="24" height="24" viewBox="0 0 24 24">
             <line x1="18" y1="6" x2="6" y2="18"/>
             <line x1="6" y1="6" x2="18" y2="18"/>
@@ -91,14 +91,14 @@
       </div>
       <div class="user">
         <img src="https://doodleipsum.com/700x700/avatar-5?i=ca71b901f3ad2ce77d50ab296aff3f5f" alt="">
-        <button title="Remove user">
+        <button aria-label="Remove user 2">
           <svg width="24" height="24" viewBox="0 0 24 24">
             <line x1="18" y1="6" x2="6" y2="18"/>
             <line x1="6" y1="6" x2="18" y2="18"/>
           </svg>
         </button>
       </div>
-      <button class="user" onclick="window.MegaDialog.showModal()">
+      <button class="user" onclick="window.MegaDialog.showModal()" aria-label="Add user">
         <svg width="24" height="24" viewBox="0 0 24 24">
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>


### PR DESCRIPTION
The two "remove user" buttons should disambiguate which user, so I added a number (since there is no disambiguation anywhere else). I also swapped the `title` to `aria-label` since if the + is clear enough for the add button's audience, the × is would be clear enough for the remove buttons.

The real issue (as in, WCAG violation) is the lack of an accessible name on the add button. So I added an `aria-label`.

I was doing SR testing and got this far before I stopped. I am hoping you can run the entire demo through SR testing with the resources at Google.