### PR TITLE
Fixed small a11y issue

### DIFF
--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -291,6 +291,7 @@ export default class Carousel {
   #createPagination() {
     let nav = document.createElement('nav')
     nav.className = 'gui-carousel--pagination'
+    nav.setAttribute('role', 'tablist')
     this.elements.root.appendChild(nav)
     
     this.elements.pagination = nav
@@ -317,7 +318,6 @@ export default class Carousel {
     marker.setAttribute('aria-label', img?.alt || caption?.innerText)
     marker.setAttribute('aria-setsize', this.elements.snaps.length)
     marker.setAttribute('aria-posinset', index)
-    marker.setAttribute('aria-controls', `carousel-item-${index}`)
     return marker
   }
 
@@ -332,7 +332,6 @@ export default class Carousel {
     marker.setAttribute('aria-label', img.alt)
     marker.setAttribute('aria-setsize', this.elements.snaps.length)
     marker.setAttribute('aria-posinset', index)
-    marker.setAttribute('aria-controls', `carousel-item-${index}`)
     return marker
   }
 
@@ -358,7 +357,6 @@ export default class Carousel {
     control.type = 'button'
     control.title = userFacingText
     control.className = `gui-carousel--control --${btnType}`
-    control.setAttribute('aria-controls', 'gui-carousel--controls')
     control.setAttribute('aria-label', userFacingText)
 
     let svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')


### PR DESCRIPTION
A made some small changes 1 is adding a "role=tablist" to the nav container because the buttons inside have a role="tab"
and "[role]s are not contained by their required parent element" as a bug.

2 i removed the aria-controls parts because they are not valid
"[aria-*] attributes do not have valid values" was the error.

I run some test on lighthouse and you can see the results in this codepen if you run lighthouse test
https://codepen.io/ROL4ND909/pen/MWqdzbz/14e32ca164655442b2c06a3590a97c40?editors=0010