### PR TITLE
bugfix: carousel.js

### DIFF
--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -98,9 +98,7 @@ export default class Carousel {
     const delta = Math.abs(scrollport.offsetLeft - element.offsetLeft)
     const scrollerPadding = parseInt(getComputedStyle(scrollport)['padding-left'])
 
-    const pos = scrollport.clientWidth / 2 > delta
-      ? delta - scrollerPadding
-      : delta + scrollerPadding
+    const pos = delta - scrollerPadding
 
     scrollport.scrollTo(dir === 'ltr' ? pos : pos*-1, 0)
   }


### PR DESCRIPTION
this solves an issue where on large screens the goToElement is skipping items.