### PR TITLE
Bugfix: carousel.js

### DIFF
--- a/carousel/carousel.js
+++ b/carousel/carousel.js
@@ -224,6 +224,11 @@ export default class Carousel {
       return
 
     e.target.setAttribute('aria-selected', true)
+    // deselect any other pagination dots
+    Array.from(this.elements.pagination.children)
+      .filter(x => x !== e.target)
+      .forEach(dot => dot.setAttribute('aria-selected', false));
+    
     const item = this.elements.snaps[this.#getElementIndex(e.target)]
 
     this.goToElement({


### PR DESCRIPTION
This fixes an issue with the navigation dots where multiple can be selected at once, due to aria-selected not being updated until scrollend.